### PR TITLE
Implement role-based dashboard endpoint

### DIFF
--- a/portal-backend.postman_collection.json
+++ b/portal-backend.postman_collection.json
@@ -64,6 +64,29 @@
       "response": []
     },
     {
+      "name": "Dashboard",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/dashboard",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "dashboard"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "List Usuarios",
       "request": {
         "method": "GET",

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const recuperacaoRoutes = require('./src/routes/recuperacaoRoutes');
 const rolesRoutes = require('./src/routes/rolesRoutes');
 const usuarioRoleRoutes = require('./src/routes/usuarioRoleRoutes');
 const permissoesRoutes = require('./src/routes/permissoesRoutes');
+const dashboardRoutes = require('./src/routes/dashboardRoutes');
 const authenticateToken = require('./src/middleware/authMiddleware');
 
 const app = express();
@@ -30,6 +31,7 @@ app.use('/api/usuarios', usuarioRoutes);
 app.use('/api/usuarios', usuarioRoleRoutes);
 app.use('/api/roles', rolesRoutes);
 app.use('/api/permissoes', permissoesRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 app.use('/api/unidade', unidadeRoutes);
 app.use('/api/licitacao', licitacaoRoutes);

--- a/src/controllers/dashboardController.js
+++ b/src/controllers/dashboardController.js
@@ -1,0 +1,54 @@
+const Comprador = require('../models/Comprador');
+const Unidade = require('../models/Unidade');
+const Usuario = require('../models/Usuarios');
+const Licitacao = require('../models/Licitacao');
+const UsuarioRole = require('../models/UsuarioRole');
+
+exports.getDashboard = async (req, res) => {
+  try {
+    const { id, roles } = req.user;
+
+    const isSuperAdmin = roles.some(r => r.nome === 'ADMIN' && !r.comprador_id && !r.unidade_id);
+    if (isSuperAdmin) {
+      const [compradores, unidades, usuarios, licitacoes] = await Promise.all([
+        Comprador.count(),
+        Unidade.count(),
+        Usuario.count(),
+        Licitacao.count()
+      ]);
+      return res.status(200).json({ compradores, unidades, usuarios, licitacoes });
+    }
+
+    const adminCompradores = roles.filter(r => r.nome === 'ADMIN' && r.comprador_id && !r.unidade_id).map(r => r.comprador_id);
+    if (adminCompradores.length) {
+      const [unidades, licitacoes, usuarios] = await Promise.all([
+        Unidade.count({ where: { comprador_id: adminCompradores } }),
+        Licitacao.count({ where: { comprador_id: adminCompradores } }),
+        UsuarioRole.count({ distinct: true, col: 'usuario_id', where: { comprador_id: adminCompradores } })
+      ]);
+      return res.status(200).json({ compradores: adminCompradores.length, unidades, usuarios, licitacoes });
+    }
+
+    const adminUnidades = roles.filter(r => r.nome === 'ADMIN' && r.unidade_id).map(r => r.unidade_id);
+    if (adminUnidades.length) {
+      const unidades = await Unidade.findAll({ attributes: ['unidade_id', 'comprador_id'], where: { unidade_id: adminUnidades } });
+      const compradorIds = [...new Set(unidades.map(u => u.comprador_id))];
+      const [licitacoes, usuarios] = await Promise.all([
+        Licitacao.count({ where: { comprador_id: compradorIds } }),
+        UsuarioRole.count({ distinct: true, col: 'usuario_id', where: { unidade_id: adminUnidades } })
+      ]);
+      return res.status(200).json({ unidades: adminUnidades.length, usuarios, licitacoes });
+    }
+
+    const pregoeiro = roles.some(r => r.nome === 'PREGOEIRO');
+    if (pregoeiro) {
+      const licitacoes = await Licitacao.count({ where: { pregoeiro_id: id } });
+      return res.status(200).json({ licitacoes });
+    }
+
+    return res.status(200).json({ message: 'Nenhum dado disponível para este usuário' });
+  } catch (error) {
+    console.error('Erro ao gerar dashboard:', error);
+    res.status(500).json({ error: 'Erro ao gerar dashboard' });
+  }
+};

--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const dashboardController = require('../controllers/dashboardController');
+
+router.get('/', dashboardController.getDashboard);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add dashboard controller and route
- register /api/dashboard route in server
- role-based dashboard provides counts for portal overview depending on user roles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a0a6ee57c832f9b65fdf45e6fe65a