### PR TITLE
Implement basic document storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+package-lock.json
+uploads/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "mysql2": "^3.14.0",
     "nodemailer": "^7.0.3",
     "nodemon": "^3.1.9",
-    "sequelize": "^6.37.7"
+    "sequelize": "^6.37.7",
+    "multer": "^1.4.5"
   },
   "scripts": {
     "start": "nodemon server.js"

--- a/portal-backend.postman_collection.json
+++ b/portal-backend.postman_collection.json
@@ -1173,6 +1173,93 @@
         }
       },
       "response": []
+    },
+    {
+      "name": "Upload Documento",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {
+              "key": "titulo",
+              "value": "Exemplo",
+              "type": "text"
+            },
+            {
+              "key": "arquivo",
+              "src": "",
+              "type": "file"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/documentos",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "documentos"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "List Documentos",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/documentos",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "documentos"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Documento",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/documentos/1",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "documentos", "1"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Delete Documento",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/documentos/1",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "documentos", "1"]
+        }
+      },
+      "response": []
     }
   ]
 }

--- a/server.js
+++ b/server.js
@@ -18,10 +18,12 @@ const rolesRoutes = require('./src/routes/rolesRoutes');
 const usuarioRoleRoutes = require('./src/routes/usuarioRoleRoutes');
 const permissoesRoutes = require('./src/routes/permissoesRoutes');
 const dashboardRoutes = require('./src/routes/dashboardRoutes');
+const documentosRoutes = require('./src/routes/documentosRoutes');
 const authenticateToken = require('./src/middleware/authMiddleware');
 
 const app = express();
 app.use(express.json());
+app.use('/arquivos', express.static('uploads'));
 app.use('/api/login', loginRoutes);
 app.use('/api/register', registerRoutes);
 
@@ -38,6 +40,7 @@ app.use('/api/licitacao', licitacaoRoutes);
 app.use('/api/compradores', compradoresRoutes);
 app.use('/api/feriadosRoutes', feriadosRoutes);
 app.use('/api', recuperacaoRoutes);
+app.use('/api/documentos', documentosRoutes);
 
 
 sequelize.authenticate().then(function(){

--- a/src/controllers/documentoController.js
+++ b/src/controllers/documentoController.js
@@ -1,0 +1,64 @@
+const Documento = require('../models/Documento');
+
+exports.upload = async (req, res) => {
+  try {
+    const { titulo, grupo_id, categoria_id } = req.body;
+    const caminho_arquivo = req.file ? req.file.path : null;
+
+    const documento = await Documento.create({
+      titulo,
+      grupo_id,
+      categoria_id,
+      caminho_arquivo
+    });
+
+    res.status(201).json(documento);
+  } catch (error) {
+    console.error('Erro ao salvar documento:', error);
+    res.status(500).json({ error: 'Erro ao salvar documento' });
+  }
+};
+
+exports.getAll = async (req, res) => {
+  try {
+    const documentos = await Documento.findAll();
+    res.status(200).json(documentos);
+  } catch (error) {
+    console.error('Erro ao listar documentos:', error);
+    res.status(500).json({ error: 'Erro ao listar documentos' });
+  }
+};
+
+exports.getById = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const documento = await Documento.findByPk(id);
+
+    if (!documento) {
+      return res.status(404).json({ error: 'Documento não encontrado' });
+    }
+
+    res.status(200).json(documento);
+  } catch (error) {
+    console.error('Erro ao buscar documento:', error);
+    res.status(500).json({ error: 'Erro ao buscar documento' });
+  }
+};
+
+exports.delete = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const documento = await Documento.findByPk(id);
+
+    if (!documento) {
+      return res.status(404).json({ error: 'Documento não encontrado' });
+    }
+
+    await documento.destroy();
+
+    res.status(200).json({ message: 'Documento deletado com sucesso' });
+  } catch (error) {
+    console.error('Erro ao deletar documento:', error);
+    res.status(500).json({ error: 'Erro ao deletar documento' });
+  }
+};

--- a/src/models/Documento.js
+++ b/src/models/Documento.js
@@ -1,0 +1,42 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/database');
+
+const Documento = sequelize.define('Documento', {
+  documento_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  grupo_id: {
+    type: DataTypes.INTEGER,
+    allowNull: true
+  },
+  categoria_id: {
+    type: DataTypes.INTEGER,
+    allowNull: true
+  },
+  titulo: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  caminho_arquivo: {
+    type: DataTypes.STRING
+  },
+  ativo: {
+    type: DataTypes.BOOLEAN,
+    defaultValue: true
+  },
+  data_criacao: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW
+  },
+  data_atualizacao: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW
+  }
+}, {
+  tableName: 'documentos',
+  timestamps: false
+});
+
+module.exports = Documento;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -10,6 +10,7 @@ db.UsuarioRole = require('./UsuarioRole');
 db.Usuario = require('./Usuarios');
 db.Comprador = require('./Comprador');
 db.Unidade = require('./Unidade');
+db.Documento = require('./Documento');
 
 // Associations
 // roles <-> permissoes

--- a/src/routes/documentosRoutes.js
+++ b/src/routes/documentosRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const documentoController = require('../controllers/documentoController');
+
+const upload = multer({ dest: 'uploads/' });
+
+router.post('/', upload.single('arquivo'), documentoController.upload);
+router.get('/', documentoController.getAll);
+router.get('/:id', documentoController.getById);
+router.delete('/:id', documentoController.delete);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Multer dependency
- expose uploads directory via `.gitignore`
- define `Documento` model
- add controller and routes for file uploads
- register document routes in express server

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684a0bcc78f8832fa551b8dc9215f232